### PR TITLE
add hatenablog editor

### DIFF
--- a/apphtml.js
+++ b/apphtml.js
@@ -252,6 +252,11 @@
             if (out == "textwell") {
                 w.location = 'textwell:///insert?text=' + encodeURIComponent(x);
             }
+            // 出力方法ごとの処理（はてなブログで新規作成）
+            if (out == "hatenablog") {
+                w.location = 'hatenablog:///new?title=new%20post&body=' + encodeURIComponent(x);
+            }
+
         }
         step = 3;
     }

--- a/apphtml2.html
+++ b/apphtml2.html
@@ -63,6 +63,7 @@ textarea{width:100%;color:#3333FF}
 <option value='thumbedit-in'>ThumbEdit(追記)</option>
 <option value='presssync'>PressSync Pro</option>
 <option value='textwell'>Textwell</option>
+<option value='hatenablog'>はてなブログ（新規投稿）</option>
 </select>
 <select id="cnt" onchange="javascript:bmClear();">
 <option value=''>（検索件数）</option>

--- a/index.html
+++ b/index.html
@@ -86,6 +86,7 @@ a:link.sig {
         <option value='thumbedit-in'>ThumbEdit(追記)</option>
         <option value='presssync'>PressSync Pro</option>
         <option value='textwell'>Textwell</option>
+        <option value='hatenablog'>はてなブログ（新規投稿）</option>
       </select>
       <br>
 


### PR DESCRIPTION
Add the url scheme of hatenablog editor 出力先エディタに「はてなブログ」のURLスキームを追加しました。新規投稿画面なのでタイトルには「new post」が自動挿入されます。 http://staff.hatenablog.com/entry/2013/05/08/175055
