### PR TITLE
Remove/Replace artworkUrl100 of software entities #39

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ deploy:
   api_key:
     secure: phXEVu7oldEDXPTp9n2UYpaLxTs66TCd6Vhy9KTnM9xF8AYyUCItQCWLJX6IIdu+nmjlPwmbFxQ1bdgypMSThU63bw6GnUYW1lgPCrTBLvRmT/R5mkF8hsuk3kold40bRWN0yplTZrpJlmAKLjDhxBdqEoirIfDa2Jj3lMcHTec=
   app:
-    deploy/hondamarlboro: appthml-h
+    deploy/hondamarlboro: apphtml-h
     deploy/feelingplace: apphtml-f
     deploy/toshiya240: apphtml-t
   on:

--- a/apphtml.js
+++ b/apphtml.js
@@ -140,12 +140,13 @@
             }
             try {
                 //artworkUrl100がないものをresultsから削除
-                for (var i = 0; i < data.results.length; i++) {
-                    if (!data.results[i].artworkUrl100) {
-                        data.results.splice(i, 1);
-                        i = i - 1;
-                    }
-                }
+                //2015/11/8 緊急パッチ。仕様変更の見極めが必要なためコメントアウトにとどめる。
+                //for (var i = 0; i < data.results.length; i++) {
+                //    if (!data.results[i].artworkUrl100) {
+                //        data.results.splice(i, 1);
+                //        i = i - 1;
+                //    }
+                //}
                 for (var i = 0; i < data.results.length; i++) {
                     json[i] = data.results[i];
                     if (knd == "software" || knd == "iPadSoftware" || knd == "macSoftware") {
@@ -503,7 +504,15 @@
             x.pubdate = data.releaseDate.replace(/-/g, '/');
             x.pubdate = x.pubdate.replace(/T.*/g, '');
             x.icon60url = data.artworkUrl60;
-            x.icon100url = data.artworkUrl100;
+            //2015/11/8緊急パッチ
+            if (data.artworkUrl100) {
+                x.icon100url = data.artworkUrl100;
+            } else if (data.artworkUrl512) {
+                x.icon100url = data.artworkUrl512;
+            } else {
+                x.icon100url = data.artworkUrl60;
+            }
+            //x.icon100url = data.artworkUrl100;
             x.artist = data.artistName;
             if (phg != "") x.artisturl = PHGUrl(data.artistViewUrl, phg);
             else x.artisturl = data.artistViewUrl;


### PR DESCRIPTION
Search APIからsoftware/iPadSoftware/macSoftwareのentityでartworkUrl100が取得できなくなっているため暫定的に以下の対応を実施

・artworkUrl100取得できない際の検索結果から除外するロジックを外す
・${icon100url}のartworkUrl100はartworkUrl512を優先的に差し替え（取得できない場合はartworkUrl60を適用）